### PR TITLE
r2pm: Fix typo on 'global-uninstall'

### DIFF
--- a/docs/tools/r2pm.md
+++ b/docs/tools/r2pm.md
@@ -73,7 +73,7 @@ DESCRIPTION
      -u, uninstall pkgname
                  Uninstall a package
 
-     -gu, global-install pkgname
+     -gu, global-uninstall pkgname
                  Uninstall a package from the system directory
 
      -l, list    List installed packages


### PR DESCRIPTION
Change global-install to global-uninstall for -gu option.